### PR TITLE
Add the ability to log to an output file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,3 @@
 0.7 (2016-02-23)
 - Add a reporter, for use with the `logs` package
+- Add `Client.add_output_file` for logging to external files

--- a/_oasis
+++ b/_oasis
@@ -34,3 +34,9 @@ Executable            reporter
   Path:               examples
   MainIs:             reporter.ml
   BuildDepends:       asl
+
+Executable            reporter_file
+  CompiledObject:     best
+  Path:               examples
+  MainIs:             reporter_file.ml
+  BuildDepends:       asl

--- a/examples/reporter.ml
+++ b/examples/reporter.ml
@@ -23,7 +23,8 @@ let src =
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let _ =
-  Logs.set_reporter (Log_asl.reporter ());
+  let client = Asl.Client.create ~ident:(Sys.executable_name) ~facility:"Daemon" () in
+  Logs.set_reporter (Log_asl.reporter ~client ());
   Log.err (fun f -> f "This is an error");
   Log.info (fun f -> f "This is informational");
   Log.debug (fun f -> f "This is lowly debugging data");

--- a/examples/reporter_file.ml
+++ b/examples/reporter_file.ml
@@ -1,0 +1,36 @@
+(*
+ * Copyright (c) 2016 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let src =
+   let src = Logs.Src.create "test" ~doc:"Test ASL using the logs library with an external file" in
+   Logs.Src.set_level src (Some Logs.Debug);
+   src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let _ =
+  let client = Asl.Client.create ~ident:(Sys.executable_name) ~facility:"Daemon" () in
+  let fd = Unix.openfile "/tmp/extralog.log" [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o0644 in
+  let msg_fmt = "$((Time)(ISO8601.6)) $((Level)(str)) - $Message" in
+  let time_fmt = "$((Time)(utc))" in
+  if not (Asl.Client.add_output_file client fd msg_fmt time_fmt `Debug)
+  then failwith "Failed to log to /tmp/extralog.log";
+  Logs.set_reporter (Log_asl.reporter ~client ());
+  Log.err (fun f -> f "This is an error");
+  Log.info (fun f -> f "This is informational");
+  Log.debug (fun f -> f "This is lowly debugging data");
+  ()

--- a/lib/asl.ml
+++ b/lib/asl.ml
@@ -15,9 +15,48 @@
  *
  *)
 
+type level = [
+  | `Emerg
+  | `Alert
+  | `Crit
+  | `Err
+  | `Warning
+  | `Notice
+  | `Info
+  | `Debug
+]
+
+external get_asl_level_EMERG: unit -> int = "stub_get_asl_level_EMERG"
+external get_asl_level_ALERT: unit -> int = "stub_get_asl_level_ALERT"
+external get_asl_level_CRIT: unit -> int = "stub_get_asl_level_CRIT"
+external get_asl_level_ERR: unit -> int = "stub_get_asl_level_ERR"
+external get_asl_level_WARNING: unit -> int = "stub_get_asl_level_WARNING"
+external get_asl_level_NOTICE: unit -> int = "stub_get_asl_level_NOTICE"
+external get_asl_level_INFO: unit -> int = "stub_get_asl_level_INFO"
+external get_asl_level_DEBUG: unit -> int = "stub_get_asl_level_DEBUG"
+
+let asl_level_EMERG = get_asl_level_EMERG()
+let asl_level_ALERT = get_asl_level_ALERT()
+let asl_level_CRIT = get_asl_level_CRIT()
+let asl_level_ERR = get_asl_level_ERR()
+let asl_level_WARNING = get_asl_level_WARNING()
+let asl_level_NOTICE = get_asl_level_NOTICE()
+let asl_level_INFO = get_asl_level_INFO()
+let asl_level_DEBUG = get_asl_level_DEBUG()
+
+let int_of_level = function
+  | `Emerg -> asl_level_EMERG
+  | `Alert -> asl_level_ALERT
+  | `Crit -> asl_level_CRIT
+  | `Err -> asl_level_ERR
+  | `Warning -> asl_level_WARNING
+  | `Notice -> asl_level_NOTICE
+  | `Info -> asl_level_INFO
+  | `Debug -> asl_level_DEBUG
+
 module Client = struct
   type t
-  
+
   type opt = [
     | `Stderr
     | `No_delay
@@ -35,7 +74,13 @@ module Client = struct
     let no_delay = List.mem `No_delay opts in
     let no_remote = List.mem `No_remote opts in
     asl_open ident facility stderr no_delay no_remote
-end 
+
+  external asl_add_output_file: t -> Unix.file_descr -> string -> string
+    -> int -> bool = "stub_asl_add_output_file"
+
+  let add_output_file t fd msg_fmt time_fmt level_up_to =
+    asl_add_output_file t fd msg_fmt time_fmt (int_of_level level_up_to)
+end
 
 module Opt = struct
   type 'a t = 'a option
@@ -80,44 +125,6 @@ module Message = struct
     m
 end
 
-type level = [
-  | `Emerg
-  | `Alert
-  | `Crit
-  | `Err
-  | `Warning
-  | `Notice
-  | `Info
-  | `Debug
-]
-
-external get_asl_level_EMERG: unit -> int = "stub_get_asl_level_EMERG"
-external get_asl_level_ALERT: unit -> int = "stub_get_asl_level_ALERT"
-external get_asl_level_CRIT: unit -> int = "stub_get_asl_level_CRIT"
-external get_asl_level_ERR: unit -> int = "stub_get_asl_level_ERR"
-external get_asl_level_WARNING: unit -> int = "stub_get_asl_level_WARNING"
-external get_asl_level_NOTICE: unit -> int = "stub_get_asl_level_NOTICE"
-external get_asl_level_INFO: unit -> int = "stub_get_asl_level_INFO"
-external get_asl_level_DEBUG: unit -> int = "stub_get_asl_level_DEBUG"
-
-let asl_level_EMERG = get_asl_level_EMERG()
-let asl_level_ALERT = get_asl_level_ALERT()
-let asl_level_CRIT = get_asl_level_CRIT()
-let asl_level_ERR = get_asl_level_ERR()
-let asl_level_WARNING = get_asl_level_WARNING()
-let asl_level_NOTICE = get_asl_level_NOTICE()
-let asl_level_INFO = get_asl_level_INFO()
-let asl_level_DEBUG = get_asl_level_DEBUG()
-
-let int_of_level = function
-  | `Emerg -> asl_level_EMERG
-  | `Alert -> asl_level_ALERT
-  | `Crit -> asl_level_CRIT
-  | `Err -> asl_level_ERR
-  | `Warning -> asl_level_WARNING
-  | `Notice -> asl_level_NOTICE
-  | `Info -> asl_level_INFO
-  | `Debug -> asl_level_DEBUG
 
 external asl_log: Client.t -> Message.t -> int -> string -> unit = "stub_asl_log"
 

--- a/lib/asl.mldylib
+++ b/lib/asl.mldylib
@@ -1,0 +1,5 @@
+# OASIS_START
+# DO NOT EDIT (digest: 0d1ff5d1164cdffcb80d38bc9c1c4a4b)
+Asl
+Log_asl
+# OASIS_STOP

--- a/lib/asl.mli
+++ b/lib/asl.mli
@@ -38,6 +38,19 @@ Apple System Log man pages}
 }
 *)
 
+type level = [
+  | `Alert
+  | `Crit
+  | `Debug
+  | `Emerg
+  | `Err
+  | `Info
+  | `Notice
+  | `Warning
+]
+(** Every message has an associated level, which is usually used for
+    filtering. *)
+
 module Client: sig
   type t
   (** A thread-unsafe client handle *)
@@ -51,12 +64,20 @@ module Client: sig
 
   val create: ident:string -> facility:string -> ?opts:opt list -> unit -> t
   (** Create a thread-unsafe client handle. *)
+
+  val add_output_file: t -> Unix.file_descr -> string -> string -> level -> bool
+  (** [add_output_file t fd msg_fmt time_fmt level_up_to] adds
+      [fd] to the set of the file descriptors used by the client [t]. Each log
+      message written via [t] will be written to [fd] if it has level
+      [level_up_to] or above. See the ASL documentation for the meaning of [msg_fmt]
+      and [time_fmt] strings. If successful, the function returns [true] and
+      [false] otherwise. *)
 end
 
 module Message: sig
 
   type t
-  (** A message provides context (keys, values, client ids etc) 
+  (** A message provides context (keys, values, client ids etc)
       for individual logs *)
 
   type ty = [
@@ -71,18 +92,6 @@ module Message: sig
   (** Construct a message, overriding some of the context.*)
 end
 
-type level = [
-  | `Alert
-  | `Crit
-  | `Debug
-  | `Emerg
-  | `Err
-  | `Info
-  | `Notice
-  | `Warning
-]
-(** Every message has an associated level, which is usually used for
-    filtering. *)
 
 val log: ?client:Client.t -> Message.t -> level -> string -> unit
 (** Send a string to the logger with the given message context and level.
@@ -92,4 +101,3 @@ val log: ?client:Client.t -> Message.t -> level -> string -> unit
     extra contention between threads. Note also the only way to have
     logs printed to stderr is to construct and use a Client.t.
   *)
-

--- a/lib/asl.mli
+++ b/lib/asl.mli
@@ -39,14 +39,14 @@ Apple System Log man pages}
 *)
 
 type level = [
+  | `Emerg  (** most severe, highest level *)
   | `Alert
   | `Crit
-  | `Debug
-  | `Emerg
   | `Err
-  | `Info
-  | `Notice
   | `Warning
+  | `Notice
+  | `Info
+  | `Debug  (** least severe, lowest level *)
 ]
 (** Every message has an associated level, which is usually used for
     filtering. *)

--- a/lib/asl.mllib
+++ b/lib/asl.mllib
@@ -1,0 +1,5 @@
+# OASIS_START
+# DO NOT EDIT (digest: 0d1ff5d1164cdffcb80d38bc9c1c4a4b)
+Asl
+Log_asl
+# OASIS_STOP

--- a/lib/asl.odocl
+++ b/lib/asl.odocl
@@ -1,0 +1,5 @@
+# OASIS_START
+# DO NOT EDIT (digest: 0d1ff5d1164cdffcb80d38bc9c1c4a4b)
+Asl
+Log_asl
+# OASIS_STOP

--- a/lib/asl_stubs.c
+++ b/lib/asl_stubs.c
@@ -70,6 +70,23 @@ CAMLprim value stub_asl_open(value ident, value facility, value stderr, value no
   CAMLreturn(alloc_client(asl));
 }
 
+CAMLprim value stub_asl_add_output_file(
+  value t, value fd, value msg_fmt, value time_fmt, value level_up_to
+) {
+  CAMLparam5(t, fd, msg_fmt, time_fmt, level_up_to);
+  CAMLlocal1(result);
+  aslclient c_asl = Asl_val(t);
+  int c_descriptor = Int_val(fd); /* assume type Unix.file_descr = int */
+  const char *c_msg_fmt = String_val(msg_fmt);
+  const char *c_time_fmt = String_val(time_fmt);
+  int c_filter = ASL_FILTER_MASK_UPTO(Int_val(level_up_to));
+  int c_text_encoding = ASL_ENCODE_SAFE;
+  result = Val_int(0); /* false */
+  if (asl_add_output_file(c_asl, c_descriptor, c_msg_fmt, c_time_fmt, c_filter, c_text_encoding) == 0) {
+    result = Val_int(1); /* true */
+  }
+  CAMLreturn(result);
+}
 
 #define Msg_val(v) (*((aslmsg *) Data_custom_val(v)))
 

--- a/lib/libasl_stubs.clib
+++ b/lib/libasl_stubs.clib
@@ -1,0 +1,4 @@
+# OASIS_START
+# DO NOT EDIT (digest: 5b20283fdd23d88f205fd26ce197a104)
+asl_stubs.o
+# OASIS_STOP

--- a/lib/log_asl.mli
+++ b/lib/log_asl.mli
@@ -17,9 +17,5 @@
 
 (** Log reporter which sends logs to the Apple System Log *)
 
-val reporter:
-     ?ident:string
-  -> ?facility:string
-  -> ?opts:Asl.Client.opt list
-  -> unit -> Logs.reporter
+val reporter: client:Asl.Client.t -> unit -> Logs.reporter
 (** Construct a Logs reporter which sends logs to Apple System Log *)


### PR DESCRIPTION
This PR also changes the Log reporter interface to require a client to be passed in. This allows an output file to be configured -- previously this was hidden and inaccessible.

Include an example showing how to use a log reporter with additional output files.
